### PR TITLE
add circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+# Elixir CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-elixir/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version here
+      - image: circleci/elixir:1.4
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: mix deps.get
+      - run: mix ecto.create
+      - run: mix test


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #8 

# Motivation and context
ci integration can ensure new changes don't break test suite before merging to master ✅ 

# What I did
- added the circleci config file
- pressed a button in the circleci dashboard 😎 

# Checklist
- [x] I have read and followed the [contributor guidelines](https://github.com/MeganeMidori/butler#contributor-guidelines)
- [x] I have run `./node_modules/.bin/eslint "web/static/js/**"` and am not merging any new eslint errors
- [x] I have run `mix credo` and am not merging any new credo errors 
- [x] I have run `mix test` and am not merging any new failing tests