### PR TITLE
addresses #23: replace placeholder with wiki definitions

### DIFF
--- a/web/models/maid.ex
+++ b/web/models/maid.ex
@@ -1,6 +1,6 @@
 defmodule Butler.Maid do
   @moduledoc """
-  Placeholder moduledoc
+  Represents a maid in the cafe
   """
 
   use Butler.Web, :model

--- a/web/models/party.ex
+++ b/web/models/party.ex
@@ -1,6 +1,6 @@
 defmodule Butler.Party do
   @moduledoc """
-  Placeholder moduledoc
+  Represents a card/barcode that belongs to a table
   """
 
   use Butler.Web, :model

--- a/web/models/reservation.ex
+++ b/web/models/reservation.ex
@@ -3,7 +3,7 @@ Protocol.derive(Jason.Encoder, Scrivener.Page)
 
 defmodule Butler.Reservation do
   @moduledoc """
-  Placeholder moduledoc
+  Represents an individual party's reservation
   """
 
   use Butler.Web, :model

--- a/web/models/table.ex
+++ b/web/models/table.ex
@@ -1,6 +1,6 @@
 defmodule Butler.Table do
   @moduledoc """
-  Placeholder moduledoc
+  Represents a table on the cafe floor
   """
 
   use Butler.Web, :model


### PR DESCRIPTION
addresses #23 

# Motivation and context
It's Hacktoberfest and I fix random elixir issues as part of it

# What I did
- change to moduledoc from placeholder comment to content from the wiki

# Checklist
- [x] I have read and followed the [contributor guidelines](https://github.com/maid51play/butler/wiki/Contributor-Workflow-(AKA-how-to-pick-up-tickets))