### PR TITLE
Maid checkin audit log

### DIFF
--- a/priv/repo/migrations/20200307173249_create_logging_table.exs
+++ b/priv/repo/migrations/20200307173249_create_logging_table.exs
@@ -2,9 +2,9 @@ defmodule Butler.Repo.Migrations.CreateLoggingTable do
   use Ecto.Migration
 
   def change do
-    create table(:logging) do
+    create table(:logs) do
       add :maid_id, references(:maids)
-      add :operation, :string
+      add :message, :string
       add :data, :string
 
       timestamps()

--- a/priv/repo/migrations/20200307173249_create_logging_table.exs
+++ b/priv/repo/migrations/20200307173249_create_logging_table.exs
@@ -1,0 +1,13 @@
+defmodule Butler.Repo.Migrations.CreateLoggingTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:logging) do
+      add :maid_id, references(:maids)
+      add :operation, :string
+      add :data, :string
+
+      timestamps()
+    end
+  end
+end

--- a/priv/repo/migrations/20200308072159_remove_unused_maid_fields.exs
+++ b/priv/repo/migrations/20200308072159_remove_unused_maid_fields.exs
@@ -1,0 +1,11 @@
+defmodule Butler.Repo.Migrations.RemoveUnusedMaidFields do
+  use Ecto.Migration
+
+  def change do
+    alter table(:maids) do
+      remove :goshujinsama, :integer
+      remove :tables, :integer
+      remove :logged_hours, :float
+    end
+  end
+end

--- a/test/controllers/maid_controller_test.exs
+++ b/test/controllers/maid_controller_test.exs
@@ -3,7 +3,7 @@ defmodule Butler.MaidControllerTest do
 
   alias Butler.Maid
 
-  @valid_attrs %{goshujinsama: 42, logged_hours: 120.5, name: "some name", status: "some status", tables: 42}
+  @valid_attrs %{name: "some name", status: "some status"}
   @invalid_attrs %{}
 
   test "lists all entries on index for a given page", %{conn: conn} do

--- a/test/models/maid_test.exs
+++ b/test/models/maid_test.exs
@@ -28,7 +28,7 @@ defmodule Butler.MaidTest do
       reservation = Repo.insert! %Reservation{}
 
       %{
-        valid_attrs: %{name: "chihiro", goshujinsama: 1, tables: 0, logged_hours: 120.5, status: "some status", checked_in_at: "2010-04-17 14:00:00.000000Z", reservation_id: reservation.id},
+        valid_attrs: %{name: "chihiro", status: "some status", checked_in_at: "2010-04-17 14:00:00.000000Z", reservation_id: reservation.id},
         invalid_attrs: %{}
       }
     end
@@ -47,7 +47,7 @@ defmodule Butler.MaidTest do
   describe "create_changeset" do
     setup do
       %{
-        valid_attrs: %{name: "chihiro", goshujinsama: 1, tables: 0, logged_hours: 120.5, status: "some status", checked_in_at: "2010-04-17 14:00:00.000000Z"},
+        valid_attrs: %{name: "chihiro", status: "some status", checked_in_at: "2010-04-17 14:00:00.000000Z"},
         invalid_attrs: %{}
       }
     end

--- a/web/controllers/maid_controller.ex
+++ b/web/controllers/maid_controller.ex
@@ -67,8 +67,13 @@ defmodule Butler.MaidController do
   end
 
   def show(conn, %{"id" => id}) do
-    maid = Repo.get!(Maid, id)
-    render(conn, "show.html", maid: maid)
+    maid = Repo.get!(Maid, id) |> Repo.preload(:logs)
+    hours = maid.logs 
+      |> Enum.map(fn log -> log.inserted_at end) 
+      |> Enum.chunk_every(2)
+      |> Enum.map(fn pair -> NaiveDateTime.diff(Enum.at(pair,1, NaiveDateTime.utc_now()), Enum.at(pair,0)) end)
+      |> Enum.reduce(0, fn x, acc -> x + acc end)
+    render(conn, "show.html", maid: maid, hours: hours)
   end
 
   def edit(conn, %{"id" => id}) do

--- a/web/controllers/maid_controller.ex
+++ b/web/controllers/maid_controller.ex
@@ -3,6 +3,8 @@ defmodule Butler.MaidController do
 
   alias Butler.Maid
 
+  alias Butler.Plug.Logger
+
   def index(conn, %{"search" => search, "page" => page}) do
     page =
       Maid
@@ -107,6 +109,7 @@ defmodule Butler.MaidController do
 
     case Repo.update(changeset) do
       {:ok, maid} ->
+        Logger.log(maid, "check_in")
         conn
           |> put_flash(:info, "#{maid.name} checked in successfully at #{DateTime.utc_now()}")
           |> redirect(to: maid_path(conn, :index))
@@ -123,6 +126,7 @@ defmodule Butler.MaidController do
 
     case Repo.update(changeset) do
       {:ok, maid} ->
+        Logger.log(maid, "check_out")
         conn
           |> put_flash(:info, "#{maid.name} checked out successfully.")
           |> redirect(to: maid_path(conn, :index))

--- a/web/controllers/maid_controller.ex
+++ b/web/controllers/maid_controller.ex
@@ -71,7 +71,7 @@ defmodule Butler.MaidController do
     hours = maid.logs 
       |> Enum.map(fn log -> log.inserted_at end) 
       |> Enum.chunk_every(2)
-      |> Enum.map(fn pair -> NaiveDateTime.diff(Enum.at(pair,1, NaiveDateTime.utc_now()), Enum.at(pair,0)) end)
+      |> Enum.map(fn pair -> NaiveDateTime.diff(Enum.at(pair, 1, NaiveDateTime.utc_now()), Enum.at(pair, 0)) end)
       |> Enum.reduce(0, fn x, acc -> x + acc end)
     render(conn, "show.html", maid: maid, hours: hours)
   end

--- a/web/controllers/maid_controller.ex
+++ b/web/controllers/maid_controller.ex
@@ -126,8 +126,7 @@ defmodule Butler.MaidController do
   def check_out(conn, %{"id" => id}) do
     maid = Repo.get!(Maid, id)
     new_hours = DateTime.diff(DateTime.utc_now(), maid.checked_in_at)
-    hours = maid.logged_hours + new_hours
-    changeset = Maid.check_in_changeset(maid, %{status: "not-present", checked_in_at: nil, logged_hours: hours})
+    changeset = Maid.check_in_changeset(maid, %{status: "not-present", checked_in_at: nil})
 
     case Repo.update(changeset) do
       {:ok, maid} ->

--- a/web/models/log.ex
+++ b/web/models/log.ex
@@ -1,4 +1,4 @@
-defmodule Butler.Logging do
+defmodule Butler.Log do
     @moduledoc """
     Placeholder moduledoc
     """
@@ -6,8 +6,8 @@ defmodule Butler.Logging do
     use Butler.Web, :model
   
     @derive {Jason.Encoder, only: [:id, :name]}
-    schema "logging" do
-      field :operation, :string
+    schema "logs" do
+      field :message, :string
       field :data, :string
   
       timestamps()
@@ -20,7 +20,7 @@ defmodule Butler.Logging do
     """
     def changeset(struct, params \\ %{}) do
       struct
-      |> cast(params, [:operation, :data])
+      |> cast(params, [:message, :data])
     end
   end
   

--- a/web/models/logging.ex
+++ b/web/models/logging.ex
@@ -1,0 +1,26 @@
+defmodule Butler.Logging do
+    @moduledoc """
+    Placeholder moduledoc
+    """
+  
+    use Butler.Web, :model
+  
+    @derive {Jason.Encoder, only: [:id, :name]}
+    schema "logging" do
+      field :operation, :string
+      field :data, :string
+  
+      timestamps()
+
+      belongs_to :maid, Butler.Maid
+    end
+
+    @doc """
+    Builds a changeset based on the `struct` and `params`.
+    """
+    def changeset(struct, params \\ %{}) do
+      struct
+      |> cast(params, [:operation, :data])
+    end
+  end
+  

--- a/web/models/maid.ex
+++ b/web/models/maid.ex
@@ -18,7 +18,7 @@ defmodule Butler.Maid do
 
     belongs_to :barcode, Butler.Barcode
     has_many :reservations, Butler.Reservation
-    has_many :logging, Butler.Logging
+    has_many :logs, Butler.Log
   end
 
   def present(query) do

--- a/web/models/maid.ex
+++ b/web/models/maid.ex
@@ -18,6 +18,7 @@ defmodule Butler.Maid do
 
     belongs_to :barcode, Butler.Barcode
     has_many :reservations, Butler.Reservation
+    has_many :logging, Butler.Logging
   end
 
   def present(query) do

--- a/web/models/maid.ex
+++ b/web/models/maid.ex
@@ -9,9 +9,6 @@ defmodule Butler.Maid do
   schema "maids" do
     field :name, :string
     field :status, :string, default: "not-present"
-    field :goshujinsama, :integer, default: 0
-    field :tables, :integer, default: 0
-    field :logged_hours, :float, default: 0.0
     field :checked_in_at, :utc_datetime, default: nil
 
     timestamps()
@@ -35,7 +32,7 @@ defmodule Butler.Maid do
 
   def check_in_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:status, :logged_hours, :checked_in_at])
+    |> cast(params, [:status, :checked_in_at])
     |> validate_required([:status])
   end
 
@@ -44,14 +41,14 @@ defmodule Butler.Maid do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :status, :goshujinsama, :tables, :logged_hours, :checked_in_at, :barcode_id])
+    |> cast(params, [:name, :status, :checked_in_at, :barcode_id])
     |> cast_assoc(:reservations)
-    |> validate_required([:name, :status, :goshujinsama, :tables, :logged_hours])
+    |> validate_required([:name, :status])
   end
 
   def create_changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:name, :status, :goshujinsama, :tables, :logged_hours, :checked_in_at, :barcode_id])
+    |> cast(params, [:name, :status, :checked_in_at, :barcode_id])
     |> validate_required([:name])
   end
 end

--- a/web/plugs/logger.ex
+++ b/web/plugs/logger.ex
@@ -1,0 +1,9 @@
+defmodule Butler.Plug.Logger do
+    def log(struct, message, data \\ "[]") do
+        %name{} = struct
+        model_name = name |> Module.split |> Enum.at(-1) |> String.downcase
+        model_atom = String.to_existing_atom("#{model_name}_id")
+        changeset = Butler.Logging.changeset(%Butler.Logging{:operation => message, :data => data} |> Map.replace!(model_atom, struct.id))
+        Butler.Repo.insert!(changeset)
+    end
+end

--- a/web/plugs/logger.ex
+++ b/web/plugs/logger.ex
@@ -1,4 +1,7 @@
 defmodule Butler.Plug.Logger do
+    @moduledoc """
+    Commits a struct change or event to the audit log
+    """
     def log(struct, message, data \\ "[]") do
         %name{} = struct
         model_name = name |> Module.split |> Enum.at(-1) |> String.downcase

--- a/web/plugs/logger.ex
+++ b/web/plugs/logger.ex
@@ -3,7 +3,7 @@ defmodule Butler.Plug.Logger do
         %name{} = struct
         model_name = name |> Module.split |> Enum.at(-1) |> String.downcase
         model_atom = String.to_existing_atom("#{model_name}_id")
-        changeset = Butler.Logging.changeset(%Butler.Logging{:operation => message, :data => data} |> Map.replace!(model_atom, struct.id))
+        changeset = Butler.Log.changeset(%Butler.Log{:message => message, :data => data} |> Map.replace!(model_atom, struct.id))
         Butler.Repo.insert!(changeset)
     end
 end

--- a/web/templates/maid/index.html.eex
+++ b/web/templates/maid/index.html.eex
@@ -26,7 +26,7 @@
       </td>
 
       <td class="text-right">
-        <span hidden><%= link "Show", to: maid_path(@conn, :show, maid) %></span>
+        <span><%= link "Show", to: maid_path(@conn, :show, maid) %></span>
         <span hidden><%= link "Edit", to: maid_path(@conn, :edit, maid), class: "btn btn-default btn-xs" %></span>
         <span hidden><%= link "Delete", to: maid_path(@conn, :delete, maid), method: :delete, data: [confirm: "Are you sure?"], class: "btn btn-danger btn-xs" %></span>
       </td>

--- a/web/templates/maid/show.html.eex
+++ b/web/templates/maid/show.html.eex
@@ -13,31 +13,25 @@
   </li>
 
   <li>
-    <strong>Goshujinsama:</strong>
-    <%= @maid.goshujinsama %>
-  </li>
-
-  <li>
-    <strong>Tables:</strong>
-    <%= @maid.tables %>
-  </li>
-
-  <li>
     <strong>Logged hours:</strong>
     <span id="logged_hours"></span>
     <script>
-    duration = moment.duration(<%= @maid.logged_hours %>*1000)
-    formatted_duration = duration.isValid() ? [duration.hours(),('0' + duration.minutes()).slice(-2)].join(':') : ''
+    duration = moment.duration(<%= @hours %>, "seconds");
+    formatted_duration = duration.isValid() ? [Math.round(duration.asHours()),('0' + duration.minutes()).slice(-2)].join(':') : ''
     $('#logged_hours').html(formatted_duration)
     </script>
   </li>
-
-  <li>
-    <strong>Logged in since:</strong>
-    <%= @maid.checked_in_at %>
-  </li>
-
 </ul>
 
 <span><%= link "Edit", to: maid_path(@conn, :edit, @maid) %></span>
 <span><%= link "Back", to: maid_path(@conn, :index) %></span>
+<br />
+<br />
+<%= for log <- @maid.logs do %>
+  <%= if log.message=="check_in" do %>
+    <div style="font-style: italic; color: grey; font-size: 11px;">Checked in at <%= log.inserted_at %> UTC</div>
+  <% end %>
+    <%= if log.message=="check_out" do %>
+    <div style="font-style: italic; color: grey; font-size: 11px;">Checked out at <%= log.inserted_at %> UTC</div>
+  <% end %>
+<% end %>


### PR DESCRIPTION
<!-- if your PR closes the linked issue: -->
resolves #68 

# Motivation and context
- in order to move away from paper check in/check out, we need an accurate account of the hours when maids were checked in
- prior to this PR, hours were tracked ad-hoc on the maid model itself. This was inconsistent and left no room for recalculation in the event of an error. It also gave no context as to when the hours were completed or in what shifts.
- This PR creates an audit log of check in/check out status on each maid, and gives a more accurate tally of hours/minutes spent checked in to the cafe.

# Screenshots
| before | after |
|---|---|
| <!-- before screenshot here --> | <!-- after screenshot here --> |
| <img width="881" alt="Screen Shot 2020-03-07 at 11 33 06 PM" src="https://user-images.githubusercontent.com/51420500/76158588-2cd56980-60cc-11ea-9146-34f436f7f19a.png"> | <img width="882" alt="Screen Shot 2020-03-07 at 11 31 50 PM" src="https://user-images.githubusercontent.com/51420500/76158589-3232b400-60cc-11ea-9e24-9f276c2e34ba.png"> |
| <img width="880" alt="Screen Shot 2020-03-07 at 11 33 19 PM" src="https://user-images.githubusercontent.com/51420500/76158594-38c12b80-60cc-11ea-9edd-ce9f2ce9b8ee.png"> | <img width="880" alt="Screen Shot 2020-03-07 at 11 32 05 PM" src="https://user-images.githubusercontent.com/51420500/76158596-3d85df80-60cc-11ea-9a35-68a56c6cca25.png"> |

# What I did

- [x] create the logging table and model
- [x] update maid controller to write to logging table on check in/check out
- [x] use log data in maid controller to display log at the bottom of the show page
- [x] use log data in maid controller to display total hours checked in
- [x] remove dead "hours" field from maid
- [x] filter the maid logs for check_in and check_out events
- [x] fix the tests

# Checklist
- [x] I have read and followed the [contributor guidelines](https://github.com/maid51play/butler/wiki/Contributor-Workflow-(AKA-how-to-pick-up-tickets))